### PR TITLE
Implemented encoding and decoding options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .pyc
 .DS_Store
 .html
+
+*.pyc
+
+*.html

--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ Note: Cooper was designed to accomodate some specific, even unusual, needs. Howe
 The main script. It may eventually offer a menu with more verbose information, so as to work better as a standalone tool. For now, Cooper has several options for specifying what you need it to do.
 
 **Use just one...**
-* -e for email - Use Cooper's phishemail.py module. Specify a FILE.
-* -p for phishgate - Use Cooper's phishgate.py module. Specify a URL.
+* -e for Email - Use Cooper's phishemail.py module. Specify a FILE.
+* -p for Phishgate - Use Cooper's phishgate.py module. Specify a URL.
 * -x for eXit - Use Cooper's phishexit.py module. Specify a URL.
+* -n for eNcode - Use Cooper to encode an image file as a Base64 string. Useful for embedding different images into a template or customizing a cloned email/website.
 
 **You can also use...**
+* -d for Decode - Indicate an email needs to be deocded and specify the encoding (base64 or quoted-printable).
 * -u for URL - Specify a URL you want Cooper to use when fixing image links in an email with images.
 * -s for Server - Add this when you want Cooper to start the HTTP server. Specify a PORT #.
 * -h - View this help information.
@@ -20,11 +22,25 @@ The main script. It may eventually offer a menu with more verbose information, s
 ###Modules:
 * toolbox.py - The toolbox handles the common tasks, such as retrieving HTML source from files and webpages and starting the HTTP server.
 
-* phishemail.py - This module handles generating phishing emails. Use -e and feed it a file.
+* phishemail.py - This module handles generating phishing emails. Use -e and feed it a file. Use -d to indicate if decoding is necessary. Use -u to provide a URL for img tags.
 
 * phishgate.py - This module creates an index.html file suitable as a phishgate (a landing page for the phishing emails). Use -p and feed Cooper a URL or file (coming soon) to have Cooper output an index.html file so the webpage can be easily viewed in your browser via the HTTP server (if you start it).
 
 * phishexit.py - This module creates an exit page for your phishing campaign. This might be a cloned copy of the phishgate website's 404 page. Use -x and feed it a URL or file (coming soon).
+
+###Usage examples:
+####Creating an email:
+* Get the source of an email to clone and save it to a file.
+* Remove the additional text (e.g. delivery info, etc.)
+* To process an email encoded in base64: cooper.py -e email.html -d base64
+
+####Creating a phishgate:
+* Find a webpage to clone.
+* To clone a webpage and view it in your browser: cooper.py -p http://www.foo.bar -s 8888
+
+####Creating an exit page:
+* Find a URL that pulls up the 404 page of your cloned website.
+* To clone the 404 page: cooper.py -x http://www.foo.bar/garbage.php
 
 ###Misc Info:
 * URLs are replaced with text that will do **nothing** for you. This is text that was needed for the particular phishing tool Cooper was created to work with. Modify the replaceURL() functions as needed.

--- a/cooper.py
+++ b/cooper.py
@@ -31,40 +31,48 @@ parser.add_option("-p", "--phishgate",  action="store", type="string", dest="gat
 parser.add_option("-e", "--email",  action="store", type="string", dest="email", help="Specifies file to use to create phishing email template")
 parser.add_option("-u", "--url",  action="store", type="string", dest="url", help="Specifies URL for images in phishing email templates")
 parser.add_option("-x", "--exit",  action="store", type="string", dest="exit", help="Specifies URL to use to create an exit template")
+parser.add_option("-d", "--decode",  action="store", type="string", dest="decode", help="Tells Cooper to decode email source (accepts base64 and quoted-printable)")
 parser.add_option("-s", "--serverport", action="store", type="int", dest="serverport", help="Use to start HTTP server after template is created")
+parser.add_option("-n", "--encode", action="store", type="string", dest="encode", help="Use to encode an image in Base64 for embedding")
 (menu, args) = parser.parse_args()
 
 #Process script options
-if menu.gate or menu.email or menu.exit or menu.serverport:
+if menu.gate or menu.email or menu.exit or menu.encode or menu.serverport or menu.decode:
 	if menu.gate:
-		print bcolors.HEADER + "[+] Processing phishgate request..." + bcolors.ENDC
+		print bcolors.HEADER + "[+] " + bcolors.ENDC + "Processing phishgate request..."
 		URL = menu.gate
 		toolbox.collectSource(URL)
 		phishgate.replaceURL()
 		phishgate.fixImageURL(URL)
 
 	if menu.email:
-		print bcolors.HEADER + "[+] Processing phishing email request..." + bcolors.ENDC
+		print bcolors.HEADER + "[+] "  + bcolors.ENDC + "Processing phishing email request..."
 		FILE = menu.email
 		toolbox.openSource(FILE)
+		if menu.decode:
+			ENCODING = menu.decode
+			phishemail.decodeEmailText(ENCODING)
 		phishemail.replaceURL()
 		if menu.url:
 			URL = menu.url
 			phishemail.fixImageURL(URL)
 		else:
-			print bcolors.WARNING + "[!] No URL specified, so images will not be processed." + bcolors.ENDC
+			print bcolors.WARNING + "[!] "  + bcolors.ENDC + "No URL specified, so images will not be processed."
 		phishemail.addTracking()
 
 	if menu.exit:
-		print bcolors.HEADER + "[+] Processing exit template request..." + bcolors.ENDC
+		print bcolors.HEADER + "[+] " + bcolors.ENDC + "Processing exit template request..."
 		URL = menu.exit
 		toolbox.collectSource(URL)
 		phishexit.replaceURL()
 		phishexit.fixImageURL(URL)
 
+	if menu.encode:
+		toolbox.encodeImage(menu.encode)
+
 	if menu.serverport:
 		PORT = menu.serverport
-		print bcolors.HEADER + "[+] Starting HTTP server on port", PORT, bcolors.ENDC
+		print bcolors.HEADER + "[+] "  + bcolors.ENDC + "Starting HTTP server on port", PORT
 		toolbox.startHTTPServer(PORT)
 else:
 	parser.print_help()

--- a/cooper.py
+++ b/cooper.py
@@ -35,7 +35,7 @@ parser.add_option("-s", "--serverport", action="store", type="int", dest="server
 (menu, args) = parser.parse_args()
 
 #Process script options
-if menu.gate or menu.email or menu.exit or menu.server:
+if menu.gate or menu.email or menu.exit or menu.serverport:
 	if menu.gate:
 		print bcolors.HEADER + "[+] Processing phishgate request..." + bcolors.ENDC
 		URL = menu.gate
@@ -64,6 +64,7 @@ if menu.gate or menu.email or menu.exit or menu.server:
 
 	if menu.serverport:
 		PORT = menu.serverport
+		print bcolors.HEADER + "[+] Starting HTTP server on port", PORT, bcolors.ENDC
 		toolbox.startHTTPServer(PORT)
 else:
 	parser.print_help()

--- a/lib/phishemail.py
+++ b/lib/phishemail.py
@@ -3,23 +3,43 @@ from BeautifulSoup import BeautifulSoup #For parsing HTML
 import urlparse #For joining URLs for <img> tags
 import base64 #For encoding and embedding images
 import urllib #For opening image URLs
+import quopri #Adds support for decoding quoted-printable text
 
 #Terminal colors!
 class bcolors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
+	HEADER = '\033[95m'
+	OKBLUE = '\033[94m'
+	OKGREEN = '\033[92m'
+	WARNING = '\033[93m'
+	FAIL = '\033[91m'
+	ENDC = '\033[0m'
+	BOLD = '\033[1m'
+	UNDERLINE = '\033[4m'
 
-#This is Step 1 - URLs are replaced with our phishing URLs and new text is saved to source.html
+#This is Step 1 - Determine encoding and decode if necessary
+def decodeEmailText(ENCODING):
+	with open('source.html', "r") as html:
+		encoded = html.read()
+		if ENCODING in ['quoted-printable', 'qp', 'q-p']:
+			print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "Decoding quoted-printable text."
+			#Decode the quoted-printable text
+			source = quopri.decodestring(encoded)
+			output = open('source.html', "w")
+			output.write(source)
+ 			output.close()
+		if ENCODING in ['base64', 'Base64', 'b64', 'B64']:
+			print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "Decoding Base64 text."
+			#Decode the Base64 text
+			source = base64.b64decode(encoded)
+			output = open('source.html', "w")
+			output.write(source)
+			output.close()
+
+#This is Step 2 - URLs are replaced with our phishing URLs and new text is saved to source.html
 def replaceURL():
 	#Provide user feedback
-	print bcolors.OKBLUE + "[+] Here come the URLs..."
-	print bcolors.OKBLUE + "[+] URLs that will be replaced:" + bcolors.ENDC
+	print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "Replacing URLs."
+	print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "URLs that will be replaced:"
 	#Open source.html, read lines, and begin parsing to replace all URLs inside <a> tags with href
 	try:
 		#Print href URLs that will be replaced
@@ -35,20 +55,20 @@ def replaceURL():
 			output = open('source.html', "w")
 			output.write(source.replace('[','').replace(']',''))
 			output.close()
-			print bcolors.OKGREEN + "[+] URL parsing successful. URLs replaced." + bcolors.ENDC
+			print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "URL parsing successful. URLs replaced."
 	except:
 		print bcolors.FAIL + "[-] URL parsing failed. Make sure the html file exists and is readable." + bcolors.ENDC
 
-#This is Step 2 - Images are found, downloaded, encoded in Base64, and embedded in source.html
+#This is Step 3 - Images are found, downloaded, encoded in Base64, and embedded in source.html
 def fixImageURL(strURL):
 	#Provide user feedback
-	print bcolors.OKBLUE + "[+] Finding IMG tags with src=/... for replacement."
-	print bcolors.OKBLUE + "[+] RegEx matches:" + bcolors.ENDC
+	print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "Finding IMG tags with src=/... for replacement."
+	print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "RegEx matches:"
 	#Open source.html, read lines, and begin parsing to replace all incomplete img src URLs
 	try:
 		#Print img src URLs that will be modified and provide info
 		print "\n".join(re.findall('src="(.*?)"', open("source.html").read()))
-		print "[+] Fixing src with " + strURL + "..."
+		print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "Fixing src with " + strURL + "..."
 		with open('source.html', "r") as html:
 			#Read in the source html and parse with BeautifulSoup
 			soup = BeautifulSoup(html)
@@ -59,7 +79,7 @@ def fixImageURL(strURL):
 				#Encode in Base64 and embed
 				img_64 = base64.b64encode(image.read())
 				img['src'] = "data:image/png;base64," + img_64
-			source = str(soup)
+			source = str(soup.prettify(encoding='utf-8'))
 			#Write the updated addresses to source.html while removing the [' and ']
 			output = open("source.html", "w")
 			output.write(source.replace('[','').replace(']',''))
@@ -69,23 +89,22 @@ def fixImageURL(strURL):
 		#Exception may occur if file doesn't exist or can't be read/written to
 		print bcolors.FAIL + "[-] IMG parsing failed. Make sure the html file exists and is readable." + bcolors.ENDC
 
-#This is Step 3 - Inserts our tracking image and writes everything to index.html
+#This is Step 4 - Inserts our tracking image and writes everything to index.html
 def addTracking():
 	#Define the tracking image that will be inserted
 	strTracking = '<img src="{{links.tracking}}" style="width:1px; height:1px;"/>'
-	print bcolors.OKBLUE + "[+] Inserting tracking image." + bcolors.ENDC
+	print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "Inserting tracking image."
 	try:
 		with open('source.html', "r") as html:
 			#Read in the source html and parse with BeautifulSoup
 			source = html.read()
 			index = source.find(r"</body")
-			print "[+] Closing body tag found at index " + str(index)
+			print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "Closing body tag found at index " + str(index)
 			tracked = source[:index] + strTracking + source[index:]
-			print bcolors.OKGREEN + "[+] Tracking has been inserted." + bcolors.ENDC
 			output = open("index.html", "w")
 			output.write(tracked.replace('[','').replace(']',''))
 			output.close()
-			print bcolors.OKGREEN + "[+] Tracking has been inserted." + bcolors.ENDC
+			print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "Tracking has been inserted."
 	except:
 		#Exception may occur if file doesn't exist or can't be read/written to
 		print bcolors.FAIL + "[-] Failed to insert tracking. Make sure the html file exists and is readable." + bcolors.ENDC

--- a/lib/phishexit.py
+++ b/lib/phishexit.py
@@ -1,25 +1,25 @@
 import re #Used for RegEx
 from BeautifulSoup import BeautifulSoup #For parsing HTML
 import urlparse #For joining URLs for <img> tags
-import base64
-import urllib
+import base64 #For encoding and embedding images
+import urllib #For opening image URLs
 
 #Terminal colors!
 class bcolors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
+	HEADER = '\033[95m'
+	OKBLUE = '\033[94m'
+	OKGREEN = '\033[92m'
+	WARNING = '\033[93m'
+	FAIL = '\033[91m'
+	ENDC = '\033[0m'
+	BOLD = '\033[1m'
+	UNDERLINE = '\033[4m'
 
 #This is Step 1 - URLs are replaced with our phishing URLs and new text is saved to source.html
 def replaceURL():
 	#Provide user feedback
-	print bcolors.OKBLUE + "[+] Here come the URLs..."
-	print bcolors.OKBLUE + "[+] URLs that will be replaced:" + bcolors.ENDC
+	print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "Replacing URLs..."
+	print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "URLs that will be replaced:"
 	#Open source, read lines, and begin parsing to replace all URLs inside <a> tags with href
 	try:
 		#Print href URLs that will be replaced
@@ -35,20 +35,20 @@ def replaceURL():
 			output = open("source.html", "w")
 			output.write(source.replace('[','').replace(']',''))
 			output.close()
-			print bcolors.OKGREEN + "[+] URL parsing successful. URLs replaced." + bcolors.ENDC
+			print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "URL parsing successful. URLs replaced."
 	except:
 		print bcolors.FAIL + "[-] URL parsing failed. Make sure the html file exists and is readable." + bcolors.ENDC
 
 #This is Step 2 - Images are found, downloaded, encoded in Base64, and embedded in index.html
 def fixImageURL(strURL):
 	#Provide user feedback
-	print bcolors.OKBLUE + "[+] Finding IMG tags with src=/... for replacement."
-	print bcolors.OKBLUE + "[+] RegEx matches:" + bcolors.ENDC
+	print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "Finding IMG tags with src=/... for replacement."
+	print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "RegEx matches:"
 	#Open source, read lines, and begin parsing to replace all incomplete img src URLs
 	try:
 		#Print img src URLs that will be modified and provide info
 		print "\n".join(re.findall('src="(.*?)"', open('source.html').read()))
-		print "[+] Fixing src with " + strURL + "..."
+		print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "Fixing src with " + strURL + "..."
 		with open('source.html', "r") as html:
 			#Read in the source html and parse with BeautifulSoup
 			soup = BeautifulSoup(html)
@@ -59,12 +59,12 @@ def fixImageURL(strURL):
 				#Encode in Base64 and embed
 				img_64 = base64.b64encode(image.read())
 				img['src'] = "data:image/png;base64," + img_64
-			source = str(soup)
+			source = str(soup.prettify(encoding='utf-8'))
 			#Write the updated addresses to source.html while removing the [' and ']
 			output = open("index.html", "w")
 			output.write(source.replace('[','').replace(']',''))
 			output.close()
-			print bcolors.OKGREEN + "[+] IMG parsing successful. IMG src's fixed." + bcolors.ENDC
+			print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "IMG parsing successful. IMG src's fixed."
 	except:
 		#Exception may occur if file doesn't exist or can't be read/written to
 		print bcolors.FAIL + "[-] IMG parsing failed. Make sure the html file exists and is readable." + bcolors.ENDC

--- a/lib/phishgate.py
+++ b/lib/phishgate.py
@@ -1,25 +1,25 @@
 import re #Used for RegEx
 from BeautifulSoup import BeautifulSoup #For parsing HTML
 import urlparse #For joining URLs for <img> tags
-import base64
-import urllib
+import base64 #For encoding and embedding images
+import urllib #For opening image URLs
 
 #Terminal colors!
 class bcolors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
+	HEADER = '\033[95m'
+	OKBLUE = '\033[94m'
+	OKGREEN = '\033[92m'
+	WARNING = '\033[93m'
+	FAIL = '\033[91m'
+	ENDC = '\033[0m'
+	BOLD = '\033[1m'
+	UNDERLINE = '\033[4m'
 
 #This is Step 1 - URLs are replaced with our phishing URLs and new text is saved to source.html
 def replaceURL():
 	#Provide user feedback
-	print bcolors.OKBLUE + "[+] Here come the URLs..."
-	print bcolors.OKBLUE + "[+] URLs that will be replaced:" + bcolors.ENDC
+	print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "Replacing URLs..."
+	print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "URLs that will be replaced:"
 	#Open source, read lines, and begin parsing to replace all URLs inside <a> tags with href
 	try:
 		#Print href URLs that will be replaced
@@ -35,20 +35,20 @@ def replaceURL():
 			output = open("source.html", "w")
 			output.write(source.replace('[','').replace(']',''))
 			output.close()
-			print bcolors.OKGREEN + "[+] URL parsing successful. URLs replaced." + bcolors.ENDC
+			print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "URL parsing successful. URLs replaced."
 	except:
 		print bcolors.FAIL + "[-] URL parsing failed. Make sure the html file exists and is readable." + bcolors.ENDC
 
 #This is Step 2 - Images are found, downloaded, encoded in Base64, and embedded in index.html
 def fixImageURL(strURL):
 	#Provide user feedback
-	print bcolors.OKBLUE + "[+] Finding IMG tags with src=/... for replacement."
-	print bcolors.OKBLUE + "[+] RegEx matches:" + bcolors.ENDC
+	print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "Finding IMG tags with src=/... for replacement."
+	print ncolors.OKGREEN + "[+] " + bcolors.ENDC + "RegEx matches:"
 	#Open source, read lines, and begin parsing to replace all incomplete img src URLs
 	try:
 		#Print img src URLs that will be modified and provide info
 		print "\n".join(re.findall('src="(.*?)"', open('source.html').read()))
-		print "[+] Fixing src with " + strURL + "..."
+		print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "Fixing src with " + strURL + "..."
 		with open('source.html', "r") as html:
 			#Read in the source html and parse with BeautifulSoup
 			soup = BeautifulSoup(html)
@@ -59,12 +59,12 @@ def fixImageURL(strURL):
 				#Encode in Base64 and embed
 				img_64 = base64.b64encode(image.read())
 				img['src'] = "data:image/png;base64," + img_64
-			source = str(soup)
+			source = str(soup.prettify(encoding='utf-8'))
 			#Write the updated addresses to source.html while removing the [' and ']
 			output = open("index.html", "w")
 			output.write(source.replace('[','').replace(']',''))
 			output.close()
-			print bcolors.OKGREEN + "[+] IMG parsing successful. IMG src's fixed." + bcolors.ENDC
+			print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "IMG parsing successful. IMG src's fixed."
 	except:
 		#Exception may occur if file doesn't exist or can't be read/written to
 		print bcolors.FAIL + "[-] IMG parsing failed. Make sure the html file exists and is readable." + bcolors.ENDC

--- a/lib/toolbox.py
+++ b/lib/toolbox.py
@@ -52,8 +52,8 @@ def startHTTPServer(PORT):
 	handler = SimpleHTTPServer.SimpleHTTPRequestHandler
 	try:
 		httpd = SocketServer.TCPServer(("", PORT), handler)
-		print "[+] Done. See output at port", PORT
+		print "[+] Done. See output at 127.0.0.1:",PORT
 		print "[+] Use CTRL+C to kill the web server."
 		httpd.serve_forever()
 	except:
-		print bcolors.FAIL + "[-] Server could not be started. Check port number." + bcolors.ENDC
+		print bcolors.FAIL + "[-] Server stopped or could not be started. Check port number." + bcolors.ENDC

--- a/lib/toolbox.py
+++ b/lib/toolbox.py
@@ -4,29 +4,30 @@ import SimpleHTTPServer #For running the SimpleHTTP server
 import urllib #For wget-like action
 import requests #For wget-like action
 from BeautifulSoup import BeautifulSoup #For parsing HTML
-import codecs
+import codecs #Avoids encoding issue when opening HTML files, like apostrophes being replaced
+import base64 #For encoding images in base64
 
 #Terminal colors!
 class bcolors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
+	HEADER = '\033[95m'
+	OKBLUE = '\033[94m'
+	OKGREEN = '\033[92m'
+	WARNING = '\033[93m'
+	FAIL = '\033[91m'
+	ENDC = '\033[0m'
+	BOLD = '\033[1m'
+	UNDERLINE = '\033[4m'
 
 #Takes a URL, scrape that webpage, and save source to source.html
 def collectSource(strURL):
-	print "[+] Grabbing source HTML from " + strURL
+	print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "Grabbing source HTML from " + strURL
 	try:
 		page = requests.get(strURL)
 		source = page.text
 		sourceFile = codecs.open("source.html", "w", encoding='utf-8')
 		sourceFile.write(source)
 		sourceFile.close()
-		print bcolors.OKGREEN + "[+] Succesfully connected to " + strURL + bcolors.ENDC
+		print bcolors.OKGREEN + "[+] "  + bcolors.ENDC + "Succesfully connected to " + strURL
 	except:
 		#If scraping fails, all is lost and we can only exit
 		print bcolors.FAIL + "[-] Check URL - Must be valid (ex: http://www.foo.bar)" + bcolors.ENDC
@@ -35,7 +36,7 @@ def collectSource(strURL):
 #Takes a txt or html file, takes contents, and dumps it into a source.html file for modification
 #Original file is preserved and new source.html file is created with utf-8 encoding to avoid encoding issues later
 def openSource(strFile):
-	print "[+] Opening source HTML file: " + strFile
+	print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "Opening source HTML file: " + strFile
 	try:
 		inputFile = open(strFile, "r")
 		source = inputFile.read()
@@ -52,8 +53,17 @@ def startHTTPServer(PORT):
 	handler = SimpleHTTPServer.SimpleHTTPRequestHandler
 	try:
 		httpd = SocketServer.TCPServer(("", PORT), handler)
-		print "[+] Done. See output at 127.0.0.1:",PORT
-		print "[+] Use CTRL+C to kill the web server."
+		print bcolors.OKGREEN + "[+] "  + bcolors.ENDC + "Done. See output at 127.0.0.1:",PORT
+		print ncolors.WARNING + "[!] " + bcolors.ENDC + "Use CTRL+C to kill the web server."
 		httpd.serve_forever()
 	except:
 		print bcolors.FAIL + "[-] Server stopped or could not be started. Check port number." + bcolors.ENDC
+
+#Takes an image file, encodes it in Base64, and prints encoded output for embedding in a template
+def encodeImage(IMAGE):
+	#Encode in Base64 and print encoded string for copying
+	with open(IMAGE, "rb") as image:
+		print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "Image has been encoded. Copy this string:\n"
+		img_64 = base64.b64encode(image.read())
+		print img_64 + "\n"
+		print ncolors.OKGREEN + "[+] " + bcolors.ENDC + "End of encoded string."


### PR DESCRIPTION
You can now use the -n option to encode a applied image file in Base64. This is just a handy option for when you want to change images in a template.

The new -d option enables you to specify the type of encoding used in an email (base64 or quoted-printable) so Cooper can decode it before moving forward with template creation.