### PR TITLE
Set env to python2 and changed output of file to index.html

### DIFF
--- a/cooper.py
+++ b/cooper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 '''
 Coopers make barrels, like cooper.py makes barrels for phish.
@@ -27,7 +27,7 @@ parser.add_option("-c", "--collect",  action="store", type="string", dest="colle
 (menu, args) = parser.parse_args()
 
 #Default filename for the output files
-OUTPUT = "output.html"
+OUTPUT = "index.html"
 
 #Does the user want images to be encoded/embedded? True or False
 EMBED = menu.embed


### PR DESCRIPTION
Nothing major but it's the little things that made my life a bit eaiser. The main reason for changing the output of the file to index.html is when you kick off a web server if the html file is output.html, a user gets a list of files to click rather than a phishing site.